### PR TITLE
Fixes 1.0

### DIFF
--- a/lib/HTTP/Cache/Transparent.pm
+++ b/lib/HTTP/Cache/Transparent.pm
@@ -46,7 +46,7 @@ LWP::Request methods) should be used as usual.
 
 use Carp;
 use LWP::UserAgent;
-use HTTP::Status qw/RC_NOT_MODIFIED RC_OK RC_PARTIAL_CONTENT/;
+use HTTP::Status qw/RC_NOT_MODIFIED RC_OK RC_PARTIAL_CONTENT status_message/;
 
 use Digest::MD5 qw/md5_hex/;
 use IO::File;
@@ -338,6 +338,7 @@ sub _get_from_cachefile {
   else {
     $res->code( RC_OK );
   }
+  $res->message(status_message($res->code) || "Unknown code");
   
   foreach my $h (@cache_headers) {
     $res->header( $h, $meta->{$h} )


### PR DESCRIPTION
This branch fixes two issues
1. When fetching from the cache without checking the server, $response->request was not being set, causing failures that did things like $response->request->uri
2. ensure $response->message is defined
