### PR TITLE
X-No-Server-Contact header generation added

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -3,6 +3,7 @@ Makefile.PL
 MANIFEST
 README
 t/HTTP-Cache-Transparent.t
+t/cache.t
 t/pod.t
 t/pod-coverage.t
 lib/HTTP/Cache/Transparent.pm

--- a/lib/HTTP/Cache/Transparent.pm
+++ b/lib/HTTP/Cache/Transparent.pm
@@ -243,6 +243,9 @@ sub _simple_request_cache {
       _get_from_cachefile( $filename, $fh, $res, $meta );
       $fh->close() 
         if defined $fh;;
+      
+      # Set X-No-Server-Contact header as content delivered without contact with external server  
+      $res->header( "X-No-Server-Contact", 1 );
 
       return $res;
     }
@@ -447,7 +450,7 @@ sub _remove_old_entries {
 
 =head1 INSPECTING CACHE BEHAVIOR
 
-The HTTP::Cache::Transparent inserts two special headers in the
+The HTTP::Cache::Transparent inserts three special headers in the
 HTTP::Response object. These can be accessed via the 
 HTTP::Response::header()-method.
 
@@ -464,6 +467,14 @@ This header is inserted and set to 1 if the content returned is the same
 as the content returned the last time this url was fetched. This header
 is always inserted and set to 1 when the response is delivered from 
 the cache.
+
+=item X-No-Server-Contact
+
+This header is inserted and set to 1 if the content returned has been
+delivered without any contact with the external server, i.e. no
+conditional or unconditional HTTP GET request has been sent, the content
+has been delivered directly from cache. This may be useful when seeking
+to control loading of the external server.
 
 =back
 

--- a/t/cache.t
+++ b/t/cache.t
@@ -1,0 +1,69 @@
+use strict;
+use warnings;
+use Test::More;
+
+use File::Temp 'tempdir';
+use LWP::Simple;
+use HTTP::Cache::Transparent;
+
+my $TMPDIR = undef;
+
+# URL of static web content to be retrieved. 
+my $url = 'http://www.example.com';
+
+# First locate some suitable tmp-dir.  We need an absolute path.
+# Will be cleaned up once test has completed.
+for my $dir (tempdir( CLEANUP => 1 ))
+{
+  if ( open(my $fh, '>', "$dir/test-$$"))
+  {
+    close($fh);
+    unlink("$dir/test-$$");
+    $TMPDIR = $dir;
+    last;
+  }
+}
+
+if ( $TMPDIR )
+{
+  $TMPDIR =~ tr|\\|/|;
+  plan tests => 8;
+}
+else
+{
+  plan skip_all => 'Cannot test without a suitable TMP Directory';
+}
+
+my $ua = LWP::UserAgent->new;
+
+# Create cache in temporary directory with a NoUpdate time of 10 secs
+HTTP::Cache::Transparent::init( { BasePath => $TMPDIR,
+                                   NoUpdate => 10 } );
+
+# Cache empty. Fetch the URL directly from the server
+my $r_init   = $ua->get($url);
+
+# Check all headers are undef
+is (defined $r_init->header('X-Cached'),            '',            'x-cached header should be undef when retrieving directly from server');
+is (defined $r_init->header('X-Content-Unchanged'), '', 'x-content-unchanged header should be undef when retrieving directly from server');
+is (defined $r_init->header('X-No-Server-Contact'), '', 'x-no-server-contact header should be undef when retrieving directly from server');
+
+# URL Cached and within NoUpdate time. Fetching URL again should return directly from cache
+my $r_cached = $ua->get($url);
+
+# Check all headers are set
+is (defined $r_cached->header('X-Cached'),            1,            'x-cached header should be set when retrieving directly from cache');
+is (defined $r_cached->header('X-Content-Unchanged'), 1, 'x-content-unchanged header should be set when retrieving directly from cache');
+is (defined $r_cached->header('X-No-Server-Contact'), 1, 'x-no-server-contact header should be set when retrieving directly from cache');
+
+# Wait for NoUpdate time to expire. 
+sleep 10;
+
+# URL Cached but outside NoUpdate time. Server should be sent conditional GET before (unchanged) content is returned from cache
+my $r_server = $ua->get($url);
+
+# Check X-Cached & X-Content-Unchanged headers are set but X-No-Server-Contact is undef
+# Setting of X-Cached header apparently difficult to predict and seems to vary from ISP to ISP. Seems to interact with X-Cache header...
+#is (defined $r_server->header('X-Cached'),            1,              'x-cached header should be set when retrieving from cache after HTTP 304 from server');
+is (defined $r_server->header('X-Content-Unchanged'),  1,   'x-content-unchanged header should be set when retrieving from cache after HTTP 304 from server');
+is (defined $r_server->header('X-No-Server-Contact'), '', 'x-no-server-contact header should be undef when retrieving from cache after HTTP 304 from server');


### PR DESCRIPTION
Hi Mattias,

As requested, here's a pull-request for the generation of the X-No-Server-Contact header. I've added a test for the correct setting of the three headers and have updated the MANIFEST accordingly.

I couldn't get the X-Cached header to be reliably generated when retrieving cached content beyond the NoUpdate time. Sometimes the header would be set, other times it would be absent. It seems to vary from ISP to ISP and may be related to the presence of the X-Cache header in the HTTP Response. Anyway, I've temporarily disabled the test for it being set in an effort to get the new tests passing clean.

I've not updated the README or Changes files as I wasn't sure if any other changes were being rolled in. 

NB. This is my first use of GitHub so please excuse if anything has been done incorrectly.

Any problems, please let me know.

Best regards,

Mike